### PR TITLE
Add simple support for iterator-based event subscription

### DIFF
--- a/traeger.py
+++ b/traeger.py
@@ -14,7 +14,7 @@ import requests
 import uuid
 import urllib
 import json
-
+import queue
 
 CLIENT_ID = "2fuohjtqv1e63dckp5v84rau0j"
 
@@ -112,3 +112,13 @@ class traeger:
                 time.sleep(1)
                 remaining -= 1                    
         return self.grill_status
+
+    def grill_status_subscription(self):
+        sub_queue = queue.Queue()
+        def handle_message(client, userdata, message):
+            sub_queue.put(json.loads(message.payload))
+        client = self.get_mqtt_client(self.grill_connect, handle_message)
+        for grill in self.grills:
+            client.subscribe(("prod/thing/update/{}".format(grill["thingName"]),1))
+        while True:
+            yield sub_queue.get()


### PR DESCRIPTION
I really like this library and it worked great on my first try! Thanks for doing the work of tracing and prototyping this to make it easy to get a good data feed out of the cloud.

As I integrated it into my standard monitoring system, I debated how often to call the `get_grill_status()` method, and as I read the code in detail, I realized it would actually be pretty easy to convert the status polling into a thread-based subscription method. With this approach, no delay is needed in the polling loop; the MQTT topic controls how frequently the client is updated.

Using this approach from the client side is even easier than polling:

```
t = traeger.traeger(username, password)

for status in t.grill_status_subscription():
    print(json.dumps(status))
```

The only downside to using this method is that you don't get to control how frequently the updates come, so if (as in your example script) you want a slower or more consistent update frequency, using the existing `get_grill_status()` method is better.